### PR TITLE
Add support to python3 removing StandardError

### DIFF
--- a/krakenio/__init__.py
+++ b/krakenio/__init__.py
@@ -12,10 +12,10 @@ import requests
 class Client(object):
     def __init__(self, api_key=None, api_secret=None):
         if api_key is None:
-            raise StandardError('Please provide Kraken.io API Key')
+            raise Exception('Please provide Kraken.io API Key')
 
         if api_secret is None:
-            raise StandardError('Please provide Kraken.io API Secret')
+            raise Exception('Please provide Kraken.io API Secret')
 
         self.api_key = api_key
         self.api_secret = api_secret
@@ -30,10 +30,10 @@ class Client(object):
 
     def url(self, image_url=None, params=None):
         if image_url is None:
-            raise StandardError('Please provide a valid image URL for optimization')
+            raise Exception('Please provide a valid image URL for optimization')
 
         if params is None:
-            raise StandardError('Please provide image optimization parameters')
+            raise Exception('Please provide image optimization parameters')
 
         api_endpoint = self.api_base_url + 'url'
 
@@ -56,14 +56,14 @@ class Client(object):
             try:
                 return r.json()
             except Exception as e:
-                raise StandardError('Could not parse JSON response from the Kraken.io API')
+                raise Exception('Could not parse JSON response from the Kraken.io API')
 
     def upload(self, file_path=None, params=None):
         if file_path is None:
-            raise StandardError('Please provide a valid file path to the image')
+            raise Exception('Please provide a valid file path to the image')
 
         if params is None:
-            raise StandardError('Please provide image optimization parameters')
+            raise Exception('Please provide image optimization parameters')
 
         api_endpoint = self.api_base_url + 'upload'
 
@@ -89,13 +89,13 @@ class Client(object):
             try:
                 return r.json()
             except Exception as e:
-                raise StandardError('Could not parse JSON response from the Kraken.io API')
+                raise Exception('Could not parse JSON response from the Kraken.io API')
 
     def upload_stringio(self, img=None, params=None):
         if img is None or not isinstance(img, cStringIO):
-            raise StandardError('Please provide a valid StringIO file like object')
+            raise Exception('Please provide a valid StringIO file like object')
         if params is None:
-            raise StandardError('Please provide image optimization parameters')
+            raise Exception('Please provide image optimization parameters')
 
         api_endpoint = self.api_base_url + 'upload'
 
@@ -121,4 +121,4 @@ class Client(object):
             try:
                 return r.json()
             except Exception as e:
-                raise StandardError('Could not parse JSON response from the Kraken.io API')
+                raise Exception('Could not parse JSON response from the Kraken.io API')

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup (
     name = 'krakenio',
-    version = '0.1.0',
+    version = '0.1.1',
     description = 'Kraken.io API Client',
     long_description = 'With this official Python client you can plug into the power and speed of Kraken.io Image Optimizer.',
     url = 'https://github.com/kraken-io/kraken-python',


### PR DESCRIPTION
`StandardError` does not exist any more in Python3. [docs](https://docs.python.org/3/library/exceptions.html). 

The suggestion to migrate from Python2 to Python3 supporting both versions is to change `StandardError` to `Exception`. [reference](https://docs.python.org/3/library/2to3.html#2to3fixer-standarderror)

Fix https://github.com/kraken-io/kraken-python/issues/8